### PR TITLE
[#4] WebDriver 인스턴스 생성 시점 변경, 태스크 등록 로직 수정

### DIFF
--- a/src/main/java/com/toy/getyourfriday/domain/WebScraper.java
+++ b/src/main/java/com/toy/getyourfriday/domain/WebScraper.java
@@ -3,8 +3,9 @@ package com.toy.getyourfriday.domain;
 import com.toy.getyourfriday.component.ProductContainer;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.WebDriverException;
+
+import java.util.Objects;
 
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toList;
@@ -14,31 +15,71 @@ public class WebScraper implements Runnable {
     public static final By CSS_SELECTOR = By.cssSelector("ul.products-list > li > a");
     public static final String ATTRIBUTE_NAME = "href";
 
-    private final WebDriver driver;
+    private WebDriver driver;
     private final ModelUrl modelUrl;
     private final ProductContainer productContainer;
 
-    public WebScraper(WebDriver driver, ModelUrl url, ProductContainer productContainer) {
+    private WebScraper(WebDriver driver, ModelUrl url, ProductContainer productContainer) {
         this.driver = driver;
         this.modelUrl = url;
         this.productContainer = productContainer;
     }
 
-    public static WebScraper of(ChromeOptions options, ModelUrl modelUrl, ProductContainer productContainer) {
-        return new WebScraper(new ChromeDriver(options), modelUrl, productContainer);
+    private WebScraper(ModelUrl modelUrl, ProductContainer productContainer) {
+        this.modelUrl = modelUrl;
+        this.productContainer = productContainer;
+    }
+
+    public static WebScraper of(ModelUrl modelUrl, ProductContainer productContainer) {
+        return new WebScraper(modelUrl, productContainer);
+    }
+
+    public static WebScraper of(WebDriver webDriver, ModelUrl modelUrl, ProductContainer productContainer) {
+        return new WebScraper(webDriver, modelUrl, productContainer);
     }
 
     @Override
     public void run() {
-        driver.get(modelUrl.getUrl());
-        Products products = driver.findElements(CSS_SELECTOR)
-                .stream()
-                .map(e -> new Product(e.getAttribute(ATTRIBUTE_NAME)))
-                .collect(collectingAndThen(toList(), Products::new));
-        productContainer.updateIfChanged(modelUrl, products);
+        try {
+            if (driver != null) {
+                driver.get(modelUrl.getUrl());
+                Products products = driver.findElements(CSS_SELECTOR)
+                        .stream()
+                        .map(e -> new Product(e.getAttribute(ATTRIBUTE_NAME)))
+                        .collect(collectingAndThen(toList(), Products::new));
+                productContainer.updateIfChanged(modelUrl, products);
+            }
+        } catch (WebDriverException e) {
+            System.out.println(e.getMessage());
+        }
+    }
+
+    public void setDriver(WebDriver driver) {
+        this.driver = driver;
     }
 
     public void quitDriver() {
-        driver.quit();
+        if (driver != null) {
+            driver.close();
+            driver.quit();
+        }
+    }
+
+    /*
+        동등성 판단 기준에는 ModelUrl만 포함된다.
+        WebDriver는 동등성을 직접 구현할 수 없기 때문에 인스턴스마다 다를 수 밖에 없으므로 비교 대상에 포함되기 힘들다.
+        ProductContainer는 싱글톤 빈이기 때문에 실시간으로 내부 데이터가 변경(업데이트)될 수 있기 때문에 비교 대상에 포함되기 힘들다.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        WebScraper scraper = (WebScraper) o;
+        return modelUrl.equals(scraper.modelUrl);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(modelUrl);
     }
 }

--- a/src/test/java/com/toy/getyourfriday/selenium/WebDriverTest.java
+++ b/src/test/java/com/toy/getyourfriday/selenium/WebDriverTest.java
@@ -1,19 +1,29 @@
 package com.toy.getyourfriday.selenium;
 
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class WebDriverTest {
 
@@ -105,6 +115,24 @@ public class WebDriverTest {
         assertNotEquals(ipAddress1, ipAddress2);
     }
 
+    @Test
+    @RepeatedTest(value = 10)
+    @DisplayName("WebDriver와 RemoteWebDriver 인스턴스 생성 시간 비교")
+    void compareWithRemoteWebDriver() {
+        long before = System.currentTimeMillis();
+        WebDriver remoteWebDriver = new RemoteWebDriver(driverService.getUrl(), new ChromeOptions());
+        long instanceTimeOfRemote = System.currentTimeMillis() - before;
+
+        before = System.currentTimeMillis();
+        WebDriver driverDefault = new ChromeDriver(new ChromeOptions());
+        long instanceTimeOfDefault = System.currentTimeMillis() - before;
+
+        assertThat(instanceTimeOfDefault > instanceTimeOfRemote).isTrue();
+        System.out.println("Default: " + instanceTimeOfDefault + ", Remote: " + instanceTimeOfRemote);
+
+        closeDriver(remoteWebDriver, driverDefault);
+    }
+
     private WebDriver createDriverByOptions(Proxy proxy, boolean headless) {
         ChromeOptions options = new ChromeOptions();
         if (proxy != null) {
@@ -112,5 +140,12 @@ public class WebDriverTest {
         }
         options.setHeadless(headless);
         return new RemoteWebDriver(driverService.getUrl(), options);
+    }
+
+    private void closeDriver(WebDriver...drivers) {
+        Arrays.stream(drivers).forEach(d -> {
+            d.close();
+            d.quit();
+        });
     }
 }

--- a/src/test/java/com/toy/getyourfriday/service/ScrapingTaskTest.java
+++ b/src/test/java/com/toy/getyourfriday/service/ScrapingTaskTest.java
@@ -7,6 +7,7 @@ import com.toy.getyourfriday.domain.WebScraper;
 import com.toy.getyourfriday.service.ScrapingManager.ScrapingTask;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -43,11 +44,13 @@ class ScrapingTaskTest {
         // given
         PeriodicTrigger trigger = new PeriodicTrigger(10, TimeUnit.SECONDS);
         WebScraper scraper = WebScraper.of(
-                new ChromeOptions(), modelUrlParser.findByName(MODEL_NAME), productContainer
+                new ChromeDriver(new ChromeOptions()),
+                modelUrlParser.findByName(MODEL_NAME),
+                productContainer
         );
         ScheduledFuture<?> scheduledFuture = taskScheduler.schedule(scraper, trigger);
         ScrapingTask task = new ScrapingTask(scheduledFuture, scraper);
-        Thread.sleep(3000);
+        Thread.sleep(3_000);
 
         // when
         task.cancel(true);


### PR DESCRIPTION
resolve #4 

# 개선 사항
- WebDriver 생성 시점을 변경하여 불필요한 WebDriver 인스턴스 생성 감소
- `ScrapingManager`의 `ConcurrentHashMap`에 태스크가 Thread-Safe하게 저장될 수 있도록 로직(주로 동등성 비교) 수정