### PR TITLE
[#29] 스크랩핑 데이터에 thumbnail 추가

### DIFF
--- a/src/main/java/com/toy/getyourfriday/domain/Product.java
+++ b/src/main/java/com/toy/getyourfriday/domain/Product.java
@@ -12,4 +12,5 @@ import lombok.ToString;
 public class Product {
 
     private final String link;
+    private final String thumbnail;
 }

--- a/src/main/java/com/toy/getyourfriday/domain/Products.java
+++ b/src/main/java/com/toy/getyourfriday/domain/Products.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static java.util.stream.Collectors.collectingAndThen;
@@ -17,6 +18,10 @@ import static java.util.stream.Collectors.toList;
 public class Products {
 
     private final List<Product> products;
+
+    public static Products of(Product... products) {
+        return new Products(Arrays.asList(products.clone()));
+    }
 
     public boolean isUpdated(Products previous) {
         if (this.products.size() > previous.size()) { // update more

--- a/src/main/java/com/toy/getyourfriday/domain/WebScraper.java
+++ b/src/main/java/com/toy/getyourfriday/domain/WebScraper.java
@@ -4,6 +4,7 @@ import com.toy.getyourfriday.component.ProductContainer;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.WebElement;
 
 import java.util.Objects;
 
@@ -12,8 +13,10 @@ import static java.util.stream.Collectors.toList;
 
 public class WebScraper implements Runnable {
 
-    public static final By CSS_SELECTOR = By.cssSelector("ul.products-list > li > a");
-    public static final String ATTRIBUTE_NAME = "href";
+    public static final By A_TAG_CSS_SELECTOR = By.cssSelector("ul.products-list > li > a");
+    public static final By IMG_CSS_SELECTOR = By.cssSelector("img");
+    public static final String A_TAG_ATTRIBUTE_NAME = "href";
+    public static final String IMG_TAG_ATTRIBUTE_NAME = "src";
 
     private WebDriver driver;
     private final ModelUrl modelUrl;
@@ -43,15 +46,20 @@ public class WebScraper implements Runnable {
         try {
             if (driver != null) {
                 driver.get(modelUrl.getUrl());
-                Products products = driver.findElements(CSS_SELECTOR)
+                Products products = driver.findElements(A_TAG_CSS_SELECTOR)
                         .stream()
-                        .map(e -> new Product(e.getAttribute(ATTRIBUTE_NAME)))
+                        .map(this::mapToProduct)
                         .collect(collectingAndThen(toList(), Products::new));
                 productContainer.updateIfChanged(modelUrl, products);
             }
         } catch (WebDriverException e) {
             System.out.println(e.getMessage());
         }
+    }
+
+    private Product mapToProduct(WebElement element) {
+        return new Product(element.getAttribute(A_TAG_ATTRIBUTE_NAME),
+                element.findElement(IMG_CSS_SELECTOR).getAttribute(IMG_TAG_ATTRIBUTE_NAME));
     }
 
     public void setDriver(WebDriver driver) {

--- a/src/test/java/com/toy/getyourfriday/domain/ProductsTest.java
+++ b/src/test/java/com/toy/getyourfriday/domain/ProductsTest.java
@@ -4,70 +4,58 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ProductsTest {
 
     private Products previous;
+    private Product existingA;
+    private Product existingB;
+    private Product updated;
 
     @BeforeEach
     void setUp() {
-        this.previous = createProductsByLinks(
-                "https://www.freitag.ch/ko/f11?productID=1143300",
-                "https://www.freitag.ch/ko/f11?productID=1135801"
-        );
+        this.existingA = new Product("https://www.freitag.ch/ko/f11?productID=1143300",
+                "https://freitag.rokka.io/neo_square_thumbnail/abc/0000-1.jpg");
+        this.existingB = new Product("https://www.freitag.ch/ko/f11?productID=1135801",
+                "https://freitag.rokka.io/neo_square_thumbnail/abc/0000-2.jpg");
+        this.updated = new Product("https://www.freitag.ch/ko/f11?productID=1135822",
+                "https://freitag.rokka.io/neo_square_thumbnail/abc/0000-3.jpg");
+        this.previous = Products.of(this.existingA, this.existingB);
     }
 
     @Test
     @DisplayName("업데이트, 판매 모두 없음")
     void isUpdatedWhenNothing() {
-        Products latest = createProductsByLinks(
-                "https://www.freitag.ch/ko/f11?productID=1143300",
-                "https://www.freitag.ch/ko/f11?productID=1135801"
-        );
+        Products latest = Products.of(existingA, existingB);
         assertThat(latest.isUpdated(previous)).isFalse();
     }
 
     @Test
     @DisplayName("업데이트 개수와 판매 개수가 동일 - 업데이트")
     void isUpdatedWhenTotalSame() {
-        Products latest = createProductsByLinks(
-                "https://www.freitag.ch/ko/f11?productID=1143300",
-                "https://www.freitag.ch/ko/f11?productID=1135822"
-        );
+        Products latest = Products.of(existingA, updated);
         assertThat(latest.isUpdated(previous)).isTrue();
     }
 
     @Test
     @DisplayName("업데이트 개수가 더 많음 - 업데이트")
     void isUpdatedWhenUpdatedMore() {
-        Products latest = createProductsByLinks(
-                "https://www.freitag.ch/ko/f11?productID=1143300",
-                "https://www.freitag.ch/ko/f11?productID=1135801",
-                "https://www.freitag.ch/ko/f11?productID=1135822"
-        );
+        Products latest = Products.of(existingA, existingB, updated);
         assertThat(latest.isUpdated(previous)).isTrue();
     }
 
     @Test
     @DisplayName("판매만 발생")
     void isUpdatedWhenOnlySold() {
-        Products latest = createProductsByLinks(
-                "https://www.freitag.ch/ko/f11?productID=1143300"
-        );
+        Products latest = Products.of(existingA);
         assertThat(latest.isUpdated(previous)).isFalse();
     }
 
     @Test
     @DisplayName("업데이트 개수보다 판매 개수가 더 많은 경우")
     void isUpdatedWhenSoldMore() {
-        Products latest = createProductsByLinks(
-                "https://www.freitag.ch/ko/f11?productID=1135822"
-        );
+        Products latest = Products.of(updated);
         assertThat(latest.isUpdated(previous)).isTrue();
     }
 
@@ -75,25 +63,12 @@ public class ProductsTest {
     @DisplayName("업데이트된 제품들만 분류")
     void getUpdatedProducts() {
         // given
-        Products latest = createProductsByLinks(
-                "https://www.freitag.ch/ko/f11?productID=1143300",
-                "https://www.freitag.ch/ko/f11?productID=1135801",
-                "https://www.freitag.ch/ko/f11?productID=1135822"
-        );
+        Products latest = Products.of(existingA, existingB, updated);
 
         // when
         Products updatedProducts = latest.getUpdatedProducts(previous);
 
         // then
-        assertThat(updatedProducts).isEqualTo(createProductsByLinks(
-                "https://www.freitag.ch/ko/f11?productID=1135822")
-        );
-    }
-
-    public static Products createProductsByLinks(String...links) {
-        List<Product> products = Arrays.stream(links)
-                .map(Product::new)
-                .collect(Collectors.toList());
-        return new Products(products);
+        assertThat(updatedProducts).isEqualTo(Products.of(updated));
     }
 }

--- a/src/test/java/com/toy/getyourfriday/selenium/WebDriverTest.java
+++ b/src/test/java/com/toy/getyourfriday/selenium/WebDriverTest.java
@@ -20,6 +20,9 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.toy.getyourfriday.domain.WebScraper.A_TAG_ATTRIBUTE_NAME;
+import static com.toy.getyourfriday.domain.WebScraper.IMG_CSS_SELECTOR;
+import static com.toy.getyourfriday.domain.WebScraper.IMG_TAG_ATTRIBUTE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -87,6 +90,11 @@ public class WebDriverTest {
         // when
         driver.get(url);
         List<WebElement> elements = driver.findElements(By.cssSelector("ul.products-list > li > a"));
+        elements.forEach(e -> {
+            System.out.println(String.format("a href: %s, img src: %s",
+                    e.getAttribute(A_TAG_ATTRIBUTE_NAME),
+                    e.findElement(IMG_CSS_SELECTOR).getAttribute(IMG_TAG_ATTRIBUTE_NAME)));
+        });
 
         // then
         System.out.println(elements.size());


### PR DESCRIPTION
Close #29 

# 구현 사항
- `Product`에 `thumbnail` 필드 추가
- `WebScraper` 클래스의 스크랩핑 로직에서 `img`태그의 `src` 속성도 함께 스크랩핑하도록 코드 수정